### PR TITLE
Improvements to heart_beat greenlet.

### DIFF
--- a/src/volttron/driver/base/driver.py
+++ b/src/volttron/driver/base/driver.py
@@ -178,9 +178,9 @@ class DriverAgent:
     def heart_beat(self):
         if self.config.heart_beat_point is None:
             return
-        self.heart_beat_value = int(not bool(self.heart_beat_value))
-        # TODO: config.heart_beat_point should be a set.
-        self.set_point(self.config.heart_beat_point, self.heart_beat_value)
+        heart_beat_value = int(not bool(self.heart_beat_value))
+        self.set_point(self.config.heart_beat_point, heart_beat_value)
+        self.heart_beat_value = heart_beat_value
 
     def get_point(self, topic, **kwargs):
         return self.interface.get_point(topic, **kwargs)


### PR DESCRIPTION
This pull request improves to the `heart_beat` method in `driver.py`. The update ensures that the `heart_beat_value` is only changed after successfully setting the point, which makes the heartbeat logic more reliable and less prone to errors.

- Reliability improvement:
  * Updated the `heart_beat` method to assign the new `heart_beat_value` only after successfully calling `set_point`, rather than before. This ensures the internal state matches the actual hardware state. (`src/volttron/driver/base/driver.py`)